### PR TITLE
make parsing of numeric parameters more robust

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4"
+    "php": ">=8.0"
   },
   "config": {
     "platform": {

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   geotag
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2023-07-14
+date   2024-08-24
 name   geotag plugin
 desc   Allow a user to annotate pages with a geotag
 url    https://www.dokuwiki.org/plugin:geotag

--- a/syntax/geotag.php
+++ b/syntax/geotag.php
@@ -136,7 +136,7 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
      * @return mixed|string
      * @throws Exception
      */
-    private function geohash(float $lat, float $lon): mixed|string
+    private function geohash(float $lat, float $lon)
     {
         if (($geophp = plugin_load('helper', 'geophp')) === null) {
             return "";

--- a/syntax/geotag.php
+++ b/syntax/geotag.php
@@ -15,6 +15,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+
 use dokuwiki\Extension\SyntaxPlugin;
 use geoPHP\Geometry\Point;
 
@@ -98,20 +99,29 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
         } elseif (array_key_exists(0, $hide) && trim($hide [0]) === 'unhide') {
             $style = '';
         }
-        $data = [hsc($lat), hsc($lon), hsc($alt), $this->geohash($lat, $lon), hsc(trim(substr(($region[0] ?? ''), 7))), hsc(trim(substr(($placename[0] ?? ''), 10))), hsc(trim(substr(($country [0] ?? ''), 8))), hsc($showlocation), $style];
-        return $data;
+        return [
+            hsc($lat),
+            hsc($lon),
+            hsc($alt),
+            $this->geohash($lat, $lon),
+            hsc(trim(substr(($region[0] ?? ''), 7))),
+            hsc(trim(substr(($placename[0] ?? ''), 10))),
+            hsc(trim(substr(($country [0] ?? ''), 8))),
+            hsc($showlocation), $style
+        ];
     }
 
     /**
-    parses numeric parameter with given name
-
-    @param string $name name of the parameter
-    @param string $input text to consume
-    @return string parameter values as numeric string or empty string if nothing is found
-    */
-    private function parseNumericParameter(string $name, string $input):string{
+     * parses numeric parameter with given name
+     *
+     * @param string $name name of the parameter
+     * @param string $input text to consume
+     * @return string parameter values as numeric string or empty string if nothing is found
+     */
+    private function parseNumericParameter(string $name, string $input): string
+    {
         $output = '';
-        $pattern = "/". $name . "\s*[:=]\s*(-?\d*\.?\d*)/";
+        $pattern = "/" . $name . "\s*[:=]\s*(-?\d*\.?\d*)/";
         if (preg_match($pattern, $input, $matches)) {
             $output = $matches[1];
         }
@@ -123,8 +133,10 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
      *
      * @param float $lat
      * @param float $lon
+     * @return mixed|string
+     * @throws Exception
      */
-    private function geohash(float $lat, float $lon)
+    private function geohash(float $lat, float $lon): mixed|string
     {
         if (($geophp = plugin_load('helper', 'geophp')) === null) {
             return "";
@@ -157,16 +169,16 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
             if ($this->getConf('geotag_prevent_microformat_render')) {
                 return true;
             }
-            $searchPre  = '';
+            $searchPre = '';
             $searchPost = '';
             if ($this->getConf('geotag_showsearch')) {
                 if (($spHelper = plugin_load('helper', 'spatialhelper_search')) !== null) {
-                    $title      = $this->getLang('findnearby') . '&nbsp;' . $placename;
-                    $url        = wl(
+                    $title = $this->getLang('findnearby') . '&nbsp;' . $placename;
+                    $url = wl(
                         getID(),
-                        ['do'  => 'findnearby', 'lat' => $ddlat, 'lon' => $ddlon]
+                        ['do' => 'findnearby', 'lat' => $ddlat, 'lon' => $ddlon]
                     );
-                    $searchPre  = '<a href="' . $url . '" title="' . $title . '">';
+                    $searchPre = '<a href="' . $url . '" title="' . $title . '">';
                     $searchPost = '<span class="a11y">' . $title . '</span></a>';
                 }
             }
@@ -189,12 +201,12 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
             return true;
         } elseif ($format === 'metadata') {
             // render metadata (our action plugin will put it in the page head)
-            $renderer->meta ['geo'] ['lat']       = $ddlat;
-            $renderer->meta ['geo'] ['lon']       = $ddlon;
+            $renderer->meta ['geo'] ['lat'] = $ddlat;
+            $renderer->meta ['geo'] ['lon'] = $ddlon;
             $renderer->meta ['geo'] ['placename'] = $placename;
-            $renderer->meta ['geo'] ['region']    = $region;
-            $renderer->meta ['geo'] ['country']   = $country;
-            $renderer->meta ['geo'] ['geohash']   = $geohash;
+            $renderer->meta ['geo'] ['region'] = $region;
+            $renderer->meta ['geo'] ['country'] = $country;
+            $renderer->meta ['geo'] ['geohash'] = $geohash;
             if (!empty($alt)) {
                 $renderer->meta ['geo'] ['alt'] = $alt;
             }
@@ -220,6 +232,7 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
      * convert latitude in decimal degrees to DMS+hemisphere.
      *
      * @param float $decimaldegrees
+     * @return string
      * @todo move this into a shared library
      */
     private function convertLat(float $decimaldegrees): string
@@ -242,11 +255,11 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
      */
     private function convertDDtoDMS(float $decimaldegrees): string
     {
-        $dms  = floor($decimaldegrees);
+        $dms = floor($decimaldegrees);
         $secs = ($decimaldegrees - $dms) * 3600;
-        $min  = floor($secs / 60);
-        $sec  = round($secs - ($min * 60), 3);
-        $dms  .= 'º' . $min . '\'' . $sec . '"';
+        $min = floor($secs / 60);
+        $sec = round($secs - ($min * 60), 3);
+        $dms .= 'º' . $min . '\'' . $sec . '"';
         return $dms;
     }
 

--- a/syntax/geotag.php
+++ b/syntax/geotag.php
@@ -98,7 +98,7 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
         } elseif (array_key_exists(0, $hide) && trim($hide [0]) === 'unhide') {
             $style = '';
         }
-        $data = [hsc($lat), hsc($lon), hsc($alt), $this->geohash($lat, $lon), hsc(trim(substr(($region[0] ?? ''), 7))), hsc(trim(substr(($placename[0] ?? >
+        $data = [hsc($lat), hsc($lon), hsc($alt), $this->geohash($lat, $lon), hsc(trim(substr(($region[0] ?? ''), 7))), hsc(trim(substr(($placename[0] ?? ''), 10))), hsc(trim(substr(($country [0] ?? ''), 8))), hsc($showlocation), $style];
         return $data;
     }
 

--- a/syntax/geotag.php
+++ b/syntax/geotag.php
@@ -72,9 +72,9 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
     {
         $tags = trim(substr($match, 9, -2));
         // parse geotag content
-        preg_match("(lat[:|=]-?\d*\.\d*)", $tags, $lat);
-        preg_match("(lon[:|=]-?\d*\.\d*)", $tags, $lon);
-        preg_match("(alt[:|=]-?\d*\.?\d*)", $tags, $alt);
+        $lat = $this->parseNumericParameter("lat", $tags);
+        $lon = $this->parseNumericParameter("lon", $tags);
+        $alt = $this->parseNumericParameter("alt", $tags);
         preg_match("/(region[:|=][\p{L}\s\w'-]*)/u", $tags, $region);
         preg_match("/(placename[:|=][\p{L}\s\w'-]*)/u", $tags, $placename);
         preg_match("/(country[:|=][\p{L}\s\w'-]*)/u", $tags, $country);
@@ -98,9 +98,24 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
         } elseif (array_key_exists(0, $hide) && trim($hide [0]) === 'unhide') {
             $style = '';
         }
-
-        $data = [hsc(trim(substr($lat [0], 4))), hsc(trim(substr($lon [0], 4))), hsc(trim(substr(($alt[0] ?? ''), 4))), $this->geohash(substr($lat [0], 4), substr($lon [0], 4)), hsc(trim(substr(($region[0] ?? ''), 7))), hsc(trim(substr(($placename[0] ?? ''), 10))), hsc(trim(substr(($country [0] ?? ''), 8))), hsc($showlocation), $style];
+        $data = [hsc($lat), hsc($lon), hsc($alt), $this->geohash($lat, $lon), hsc(trim(substr(($region[0] ?? ''), 7))), hsc(trim(substr(($placename[0] ?? >
         return $data;
+    }
+
+    /**
+    parses numeric parameter with given name
+
+    @param string $name name of the parameter
+    @param string $input text to consume
+    @return string parameter values as numeric string or empty string if nothing is found
+    */
+    private function parseNumericParameter(string $name, string $input):string{
+        $output = '';
+        $pattern = "/". $name . "\s*[:=]\s*(-?\d*\.?\d*)/";
+        if (preg_match($pattern, $input, $matches)) {
+            $output = $matches[1];
+        }
+        return $output;
     }
 
     /**

--- a/syntax/geotag.php
+++ b/syntax/geotag.php
@@ -133,12 +133,12 @@ class syntax_plugin_geotag_geotag extends SyntaxPlugin
      *
      * @param float $lat
      * @param float $lon
-     * @return mixed|string
+     * @return string
      * @throws Exception
      */
-    private function geohash(float $lat, float $lon): mixed|string
+    private function geohash(float $lat, float $lon): string
     {
-        if (($geophp = plugin_load('helper', 'geophp')) === null) {
+        if ((plugin_load('helper', 'geophp')) === null) {
             return "";
         }
 


### PR DESCRIPTION
accepts now spaces between parameter name and =|:, between =|:  and number and integers instead of floats

closes #40 